### PR TITLE
docs: track netsh decoding issue

### DIFF
--- a/issues/0001-netsh-decoding.md
+++ b/issues/0001-netsh-decoding.md
@@ -1,0 +1,17 @@
+# Issue: Decode UTF-16 netsh output before parsing
+
+## Summary
+The service invokes `netsh` to reconcile Windows portproxy and firewall state. However, `netsh` emits UTF-16 text. The current code in `checkFirewallRules` and `getCurrentPortMappings` assumes UTF-8 and passes raw `cmd.Output()` bytes directly into string parsing helpers. On Windows, this fails to match existing rules and entries, causing warnings about missing permissions and repeated attempts to recreate state that already exists.
+
+## Impact
+- Validator reports false negatives for existing port proxy and firewall rules.
+- Runtime reconciliation loops reapply mappings unnecessarily, wasting time and obscuring real errors.
+- Firewall automation cannot distinguish between genuine failures and encoding issues, reducing operator confidence before release.
+
+## Proposal
+1. Add a helper (e.g., `decodeCommandOutput([]byte) (string, error)`) in `main.go` that detects UTF-16LE/BE command output via BOM or interleaved NUL bytes and converts it to UTF-8.
+2. Use the helper to preprocess `netsh` command output in both `checkFirewallRules` and `getCurrentPortMappings`.
+3. Extend `main_test.go` with tests that cover representative UTF-16LE samples to confirm decoding and parsing succeed.
+
+## Testing
+- To be covered by the proposed unit tests once implemented.

--- a/issues/0004-wsl-bom-handling.md
+++ b/issues/0004-wsl-bom-handling.md
@@ -1,0 +1,17 @@
+# Issue: Strip UTF-16 BOM from WSL instance listings
+
+## Summary
+`getRunningWSLInstances` shells out to `wsl --list --running --quiet` and then splits the command output into distro names. On Windows, the command emits UTF-16 with a byte-order mark (BOM). After decoding to UTF-8, the code retains the leading `\ufeff` rune on the first line, so the first running instance never matches the configuration keys.
+
+## Impact
+- The first running WSL distribution is skipped during reconciliation, so any port mappings for that instance are never applied.
+- Validators that check for running instances may report false negatives, reducing confidence in the service status.
+- Operators may see flaky behavior where the first configured distro is ignored until another distribution starts and shifts the order.
+
+## Proposal
+1. Extend the command output decoding helper (or add a post-processing step) to detect and remove a leading BOM before splitting into lines.
+2. Update `getRunningWSLInstances` to strip the BOM and ensure the resulting map keys match the expected distro names exactly.
+3. Add regression tests to `main_test.go` that feed UTF-16LE samples containing a BOM and verify the decoded instance list is clean.
+
+## Testing
+- Covered by the proposed regression tests once implemented.


### PR DESCRIPTION
## Summary
- add an issue record documenting the need to decode UTF-16 netsh output before parsing
- outline impact and proposal for addressing the decoding bug in firewall and portproxy management

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d131774ac08329b33a1905fc0130d8